### PR TITLE
Fix timestamps and where expression

### DIFF
--- a/lib/cassandra_ecto/adapter.ex
+++ b/lib/cassandra_ecto/adapter.ex
@@ -270,15 +270,12 @@ defmodule Cassandra.Ecto.Adapter do
   end
 
   defp timestamp_decode(timestamp) do
-    usec = timestamp |> rem(1_000_000)
-    timestamp = timestamp |> div(1_000_000)
-    {date, time} = :calendar.gregorian_seconds_to_datetime(timestamp)
-    time = time |> Tuple.append(usec)
-    {:ok, {date, time}}
+    {:ok, Ecto.DateTime.from_unix!(timestamp, :millisecond) |> Ecto.DateTime.to_erl()}
   end
 
   defp timestamp_encode({{y, m, d}, {h, i, s, usec}}), do:
-    {:ok, :calendar.datetime_to_gregorian_seconds({{y, m, d}, {h, i, s}}) * 1_000_000 + usec}
+    {:ok, %DateTime{calendar: Calendar.ISO, day: d, hour: h, microsecond: {usec, 3}, minute: i, second: s, std_offset: 0, month: m, time_zone: "Etc/UTC", utc_offset: 0, year: y, zone_abbr: "UTC"}
+      |> DateTime.to_unix(:millisecond)}
 
   @doc """
   See `c:Ecto.Adapter.prepare/2`

--- a/lib/cassandra_ecto/adapter.ex
+++ b/lib/cassandra_ecto/adapter.ex
@@ -270,7 +270,7 @@ defmodule Cassandra.Ecto.Adapter do
   end
 
   defp timestamp_decode(timestamp) do
-    {:ok, Ecto.DateTime.from_unix!(timestamp, :milliseconds) |> Ecto.DateTime.to_erl()}
+    Ecto.DateTime.from_unix!(timestamp, :milliseconds) |> Ecto.DateTime.dump()
   end
 
   defp timestamp_encode({{y, m, d}, {h, i, s, usec}}), do:

--- a/lib/cassandra_ecto/adapter.ex
+++ b/lib/cassandra_ecto/adapter.ex
@@ -166,7 +166,7 @@ defmodule Cassandra.Ecto.Adapter do
   def execute(repo, %{fields: fields}, {_cache, {func, query}}, params, process, opts) do
     opts = prepare_opts(func, repo, opts)
     cql = to_cql(func, query, opts)
-    names = get_names(query)
+    names = get_names(query, opts)
     params = Enum.zip(names, params) ++ if_fields(opts)
     case Connection.query(repo, cql, params, opts) do
       {:ok, %{rows: rows, num_rows: num, command: :select}} -> {num, rows |> Enum.map(&process_row(&1, process, fields))}
@@ -270,12 +270,12 @@ defmodule Cassandra.Ecto.Adapter do
   end
 
   defp timestamp_decode(timestamp) do
-    {:ok, Ecto.DateTime.from_unix!(timestamp, :millisecond) |> Ecto.DateTime.to_erl()}
+    {:ok, Ecto.DateTime.from_unix!(timestamp, :milliseconds) |> Ecto.DateTime.to_erl()}
   end
 
   defp timestamp_encode({{y, m, d}, {h, i, s, usec}}), do:
     {:ok, %DateTime{calendar: Calendar.ISO, day: d, hour: h, microsecond: {usec, 3}, minute: i, second: s, std_offset: 0, month: m, time_zone: "Etc/UTC", utc_offset: 0, year: y, zone_abbr: "UTC"}
-      |> DateTime.to_unix(:millisecond)}
+      |> DateTime.to_unix(:milliseconds)}
 
   @doc """
   See `c:Ecto.Adapter.prepare/2`

--- a/lib/cassandra_ecto/adapter/cql.ex
+++ b/lib/cassandra_ecto/adapter/cql.ex
@@ -125,8 +125,13 @@ defmodule Cassandra.Ecto.Adapter.CQL do
 
   defp where_names(opts), do: Keyword.get(opts, :where_names, nil)
 
-  defp allow_filtering([allow_filtering: true]), do: "ALLOW FILTERING"
-  defp allow_filtering(_), do: ""
+  defp allow_filtering(opts) do
+    if Keyword.get(opts, :allow_filtering, false) do
+      "ALLOW FILTERING"
+    else
+      ""
+    end
+  end
 
   defp per_partition_limit([per_partition_limit: num]) when is_integer(num),
     do: "PER PARTITION LIMIT " <> Integer.to_string(num)

--- a/lib/cassandra_ecto/adapter/cql.ex
+++ b/lib/cassandra_ecto/adapter/cql.ex
@@ -171,21 +171,18 @@ defmodule Cassandra.Ecto.Adapter.CQL do
   defp boolean(name, [%{expr: expr} | query_exprs], query) do
     name <> " " <> Enum.reduce(query_exprs, expr(expr, query), fn
         %BooleanExpr{expr: expr, op: op}, {op, acc} ->
-          {op, acc <> operator_to_boolean(op) <> paren_expr(expr, query)}
+          {op, acc <> operator_to_boolean(op) <> expr(expr, query)}
         %BooleanExpr{expr: expr, op: op}, {_, acc} ->
-          {op, "(" <> acc <> ")" <> operator_to_boolean(op) <> paren_expr(expr, query)}
+          {op, acc <> operator_to_boolean(op) <> expr(expr, query)}
       end)
   end
 
   defp operator_to_boolean(:and), do: " AND "
-  defp operator_to_boolean(:or), do: " OR "
-
-  defp paren_expr(expr, query), do:
-    "(" <> expr(expr, query) <> ")"
+  defp operator_to_boolean(:and), do: error! nil, "Cassandra adapter does not support :or operator"
 
   binary_ops =
     [==: "=", !=: "!=", <=: "<=", >=: ">=",
-      <:  "<", >:  ">", and: "AND", or: "OR", like: "LIKE"]
+      <:  "<", >:  ">", and: "AND", like: "LIKE"]
 
   @binary_ops Keyword.keys(binary_ops)
 

--- a/lib/cassandra_ecto/helper.ex
+++ b/lib/cassandra_ecto/helper.ex
@@ -70,12 +70,22 @@ defmodule Cassandra.Ecto.Helper do
     |> Enum.join(joiner)
   end
 
-  def get_names(query), do:
-    get_update_names(query) ++ get_where_names(query)
+  def get_names(query), do: get_names(query, [])
+  def get_names(query, opts) do
+    update_names = get_update_names(query)
+    where_names =
+      case Keyword.get(opts, :where_names) do
+         names when is_list(names) ->
+           names |> Enum.with_index(length(update_names)) |> Enum.map(fn {k, v} -> {v, k} end)
+         _ ->
+           get_where_names(query)
+      end
+    update_names ++ where_names
     |> List.flatten
     |> Enum.sort(&(elem(&1, 0) < elem(&2, 0)))
     |> Enum.unzip
     |> elem(1)
+  end
 
   def process_row(row, process, fields) do
     Enum.map_reduce(fields, row, fn

--- a/spec/cassandra_ecto/adapter_spec.exs
+++ b/spec/cassandra_ecto/adapter_spec.exs
@@ -61,6 +61,13 @@ defmodule CassandraEctoAdapterSpec do
               expect(TestRepo.all((from p in Post, where: "abra" in p.tags and p.text == "test" and p.title == "test"), allow_filtering: true) |> List.first |> Map.get(:id))
               |> to(eq id)
             end
+            it "fetches record with multiple where clauses and binded var names" do
+              tags = "abra"
+              text = "test"
+              title = "test"
+              expect(TestRepo.all((from p in Post, where: ^tags in p.tags and p.text == ^text and p.title == ^title), [allow_filtering: true, where_names: [:tags, :text, :title]]) |> List.first |> Map.get(:id))
+              |> to(eq id)
+            end
             it "writes log to io in :cyan when logging enabled" do
               message = capture_log(fn ->
                 TestRepo.all((from p in Post), log: true)

--- a/spec/support/factories.exs
+++ b/spec/support/factories.exs
@@ -9,7 +9,7 @@ defmodule Cassandra.Ecto.Spec.Support.Factories do
   end
   def factory(:comments, args, _opts), do:
     Enum.map((1..10), fn
-      arg -> Map.merge(args, %{text: "text #{arg}", posted_at: Ecto.DateTime.utc(:usec)})
+      arg -> Map.merge(args, %{text: "text #{arg}", posted_at: Ecto.DateTime.utc(:sec)})
     end)
   def factory(type, args, with: items) when is_list(items), do:
     Enum.reduce(items, factory(type, args, []), fn

--- a/spec/support/schemas.exs
+++ b/spec/support/schemas.exs
@@ -15,7 +15,7 @@ defmodule Cassandra.Ecto.Spec.Support.Schemas do
       field      :name,  :string
       has_many   :posts, Post, foreign_key: :author_id
       embeds_one :personal_info, PersonalInfo
-      timestamps()
+      timestamps(usec: false)
     end
   end
   defmodule PersonalInfo do
@@ -38,7 +38,7 @@ defmodule Cassandra.Ecto.Spec.Support.Schemas do
       field :links,    {:map, :string}
       embeds_many :comments, Comment
       belongs_to  :author,   User
-      timestamps()
+      timestamps(usec: false)
     end
   end
   defmodule PostStats do


### PR DESCRIPTION
I tried to use you library and run into some issuse.

1. Datetime was encoded in gregorian seconds and that is not valid cassandra  timestamp format.

2. I tried to run query that has where expression like this `where: event.id == ^id and event.ts > ^time_start and event.ts < ^time_end`

First problem is that multiple `and`'s would end up wrapped in parens which are not supported by cassandra. I also disabled or expression as cassandra doesn't support it.

Second problem was that in order for expression to work twice with same field variables have to be name bound so I added that.

It works with my code, but I had problem with running test suite in your lib so there are no test for this.

Code could use some improvement so pls comment anything.